### PR TITLE
Fetch all media

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ func (c *Config) readConfigFromFile() {
 		c.SaveLocation = filepath.Join(homeDir, "Downloads/meetings")
 		c.Resolution = RES720
 		c.Language = "E"
+		c.PubSymbols = []string{"th", "rr"}
 		c.writeConfigToFile()
 	}
 
@@ -65,6 +66,7 @@ func (c *Config) writeConfigToFile() {
 		Resolution           string
 		SaveLocation         string
 		Language             string
+		PubSymbols           []string
 	}{
 		AutoFetchMeetingData: c.AutoFetchMeetingData,
 		FetchOtherMedia:      c.FetchOtherMedia,
@@ -73,6 +75,7 @@ func (c *Config) writeConfigToFile() {
 		Resolution:           c.Resolution,
 		SaveLocation:         c.SaveLocation,
 		Language:             c.Language,
+		PubSymbols:           c.PubSymbols,
 	}
 
 	configToml, err := toml.Marshal(config)

--- a/gui.go
+++ b/gui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -135,9 +136,25 @@ func (c *Config) settingsGUI() *fyne.Container {
 	lang.SetPlaceHolder("MEPS Language Symbol (eg. E)")
 	lang.SetText(c.Language)
 
+	pubs := widget.NewEntry()
+	pubs.SetPlaceHolder("Linked publication symbols to allow (eg. th, rr)")
+	var pubSymbolString string
+	for i, s := range c.PubSymbols {
+		if i != 0 {
+			pubSymbolString += ", "
+		}
+		pubSymbolString += s
+	}
+	pubs.SetText(pubSymbolString)
+
 	save := widget.NewButton("Save", func() {
 		c.SaveLocation = targetDir.Text
 		c.Language = lang.Text
+		var pubSymbolSlice []string
+		for _, p := range strings.Split(pubs.Text, ",") {
+			pubSymbolSlice = append(pubSymbolSlice, strings.TrimSpace(strings.ToLower(p)))
+		}
+		c.PubSymbols = pubSymbolSlice
 		c.writeConfigToFile()
 	})
 
@@ -146,6 +163,7 @@ func (c *Config) settingsGUI() *fyne.Container {
 		targetDir,
 		purgeDir,
 		lang,
+		pubs,
 		save,
 	)
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"flag"
+
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -18,9 +21,15 @@ const (
 )
 
 func main() {
-	// logrus.SetLevel(logrus.DebugLevel)
 	config := NewConfig()
 	a := app.New()
+
+	config.DebugMode = flag.Bool("d", false, "fake downloading; print debug info")
+	flag.Parse()
+	if *config.DebugMode {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Debug("RUNNING IN DEBUG MODE")
+	}
 
 	progressBar := widget.NewProgressBar()
 	config.Progress = &progress{0, "", progressBar}

--- a/structs.go
+++ b/structs.go
@@ -19,9 +19,11 @@ type Config struct {
 	Songs                []string
 	Pictures             []file
 	Videos               []video
+	PubSymbols           []string
 	Progress             *progress
 	HttpClient           *retryablehttp.Client
 	Date                 time.Time
+	DebugMode            *bool
 }
 
 type video struct {
@@ -30,6 +32,11 @@ type video struct {
 	MepsDocumentID sql.NullInt64
 	Track          sql.NullInt64
 	KeySymbol      sql.NullString
+}
+
+type mepsDocument struct {
+	video
+	MimeType string
 }
 
 type mediaInfo struct {
@@ -91,9 +98,16 @@ type Media struct {
 type Files struct {
 	Progressivedownloadurl string `json:"progressiveDownloadURL"`
 	Filesize               int    `json:"filesize"`
+	Label                  string `json:"label"`
+	Subtitled              bool   `json:"subtitled"`
 }
 
 type Multimedia struct {
 	Track    string
 	FilePath string
+}
+
+type LinkedDocument struct {
+	PublicationSymbol string
+	MepsDocumentID    string
 }


### PR DESCRIPTION
- The identification of all mwb docs per date has been fixed
  - This in turn fixes the fetching of pics from mwb
- Add the fetching of linked documents and its pics and videos
- Add setting to control which publications are fetched as linked
  documents. This will limit the fetching of docs like `it`, `w`, etc
  which aren't often used for their media. The drawback to this is that
  it will need to be updated as the CBS publication changes.
- Added debug flag